### PR TITLE
Fix if getting gziped contents from exporter

### DIFF
--- a/prome/prometheus.go
+++ b/prome/prometheus.go
@@ -205,8 +205,5 @@ func (p Plugin) scrape(ctx context.Context, url string, w io.Writer) (string, er
 	}
 
 	_ = gzipr.Close()
-	if err != nil {
-		return "", err
-	}
 	return resp.Header.Get("Content-Type"), nil
 }

--- a/prome/prometheus_test.go
+++ b/prome/prometheus_test.go
@@ -1,12 +1,23 @@
 package prome
 
 import (
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
+
+type gzipResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+}
+
+func (w gzipResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
 
 func TestNewPlugin(t *testing.T) {
 	in := `# HELP test metrics
@@ -37,9 +48,49 @@ test_more_metrics_bytes{role="a" } 256.0`
 		t.Errorf("got %v want %v", len(m), 4)
 	}
 }
+func TestNewPluginGzip(t *testing.T) {
+	in := `# HELP test metrics
+# 	TYPE test_metrics_seconds counter
+test_metrics_seconds{role="a" } 4.9351e-05
+test_metrics_seconds{role="b",group="d"} 8.3835e-05
+test_metrics_seconds{ role="c", group="e"} 8.3835e-05
+
+# HELP test more metrics
+# 	TYPE test_more_metrics_bytes gauge
+test_more_metrics_bytes{role="a" } 256.0`
+
+	ts := newMockGzipServer(in)
+	targets := []string{ts.URL}
+	prefix := ""
+	ctx := context.Background()
+	p, err := NewPlugin(ctx, NewHTTPClient(), targets, prefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := p.GraphDefinition()
+	if len(g) != 2 {
+		t.Errorf("got %v want %v", len(g), 2)
+	}
+
+	m, _ := p.FetchMetrics()
+	if len(m) != 4 {
+		t.Errorf("got %v want %v", len(m), 4)
+	}
+}
 
 func newMockServer(in string) *httptest.Server {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "%s", in)
+	})
+	return httptest.NewServer(handler)
+}
+
+func newMockGzipServer(in string) *httptest.Server {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		gz := gzip.NewWriter(w)
+		defer gz.Close()
+		w = gzipResponseWriter{Writer: gz, ResponseWriter: w}
 		fmt.Fprintf(w, "%s", in)
 	})
 	return httptest.NewServer(handler)

--- a/prome/prometheus_test.go
+++ b/prome/prometheus_test.go
@@ -20,7 +20,21 @@ func (w gzipResponseWriter) Write(b []byte) (int, error) {
 }
 
 func TestNewPlugin(t *testing.T) {
-	in := `# HELP test metrics
+	for _, td := range []struct {
+		title    string
+		use_gzip bool
+	}{
+		{
+			title:    "plain",
+			use_gzip: false,
+		},
+		{
+			title:    "gzip",
+			use_gzip: true,
+		},
+	} {
+		t.Run(td.title, func(t *testing.T) {
+			in := `# HELP test metrics
 # 	TYPE test_metrics_seconds counter
 test_metrics_seconds{role="a" } 4.9351e-05
 test_metrics_seconds{role="b",group="d"} 8.3835e-05
@@ -30,67 +44,35 @@ test_metrics_seconds{ role="c", group="e"} 8.3835e-05
 # 	TYPE test_more_metrics_bytes gauge
 test_more_metrics_bytes{role="a" } 256.0`
 
-	ts := newMockServer(in)
-	targets := []string{ts.URL}
-	prefix := ""
-	ctx := context.Background()
-	p, err := NewPlugin(ctx, NewHTTPClient(), targets, prefix)
-	if err != nil {
-		t.Fatal(err)
-	}
-	g := p.GraphDefinition()
-	if len(g) != 2 {
-		t.Errorf("got %v want %v", len(g), 2)
-	}
+			ts := newMockServer(in, td.use_gzip)
+			targets := []string{ts.URL}
+			prefix := ""
+			ctx := context.Background()
+			p, err := NewPlugin(ctx, NewHTTPClient(), targets, prefix)
+			if err != nil {
+				t.Fatal(err)
+			}
+			g := p.GraphDefinition()
+			if len(g) != 2 {
+				t.Errorf("got %v want %v", len(g), 2)
+			}
 
-	m, _ := p.FetchMetrics()
-	if len(m) != 4 {
-		t.Errorf("got %v want %v", len(m), 4)
-	}
-}
-func TestNewPluginGzip(t *testing.T) {
-	in := `# HELP test metrics
-# 	TYPE test_metrics_seconds counter
-test_metrics_seconds{role="a" } 4.9351e-05
-test_metrics_seconds{role="b",group="d"} 8.3835e-05
-test_metrics_seconds{ role="c", group="e"} 8.3835e-05
-
-# HELP test more metrics
-# 	TYPE test_more_metrics_bytes gauge
-test_more_metrics_bytes{role="a" } 256.0`
-
-	ts := newMockGzipServer(in)
-	targets := []string{ts.URL}
-	prefix := ""
-	ctx := context.Background()
-	p, err := NewPlugin(ctx, NewHTTPClient(), targets, prefix)
-	if err != nil {
-		t.Fatal(err)
-	}
-	g := p.GraphDefinition()
-	if len(g) != 2 {
-		t.Errorf("got %v want %v", len(g), 2)
-	}
-
-	m, _ := p.FetchMetrics()
-	if len(m) != 4 {
-		t.Errorf("got %v want %v", len(m), 4)
+			m, _ := p.FetchMetrics()
+			if len(m) != 4 {
+				t.Errorf("got %v want %v", len(m), 4)
+			}
+		})
 	}
 }
 
-func newMockServer(in string) *httptest.Server {
+func newMockServer(in string, use_gzip bool) *httptest.Server {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "%s", in)
-	})
-	return httptest.NewServer(handler)
-}
-
-func newMockGzipServer(in string) *httptest.Server {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Encoding", "gzip")
-		gz := gzip.NewWriter(w)
-		defer gz.Close()
-		w = gzipResponseWriter{Writer: gz, ResponseWriter: w}
+		if use_gzip {
+			w.Header().Set("Content-Encoding", "gzip")
+			gz := gzip.NewWriter(w)
+			defer gz.Close()
+			w = gzipResponseWriter{Writer: gz, ResponseWriter: w}
+		}
 		fmt.Fprintf(w, "%s", in)
 	})
 	return httptest.NewServer(handler)


### PR DESCRIPTION
There was no metric when the exporter returned gziped content.
because io.copyN always return EOF err.

The error handling here(https://github.com/k1LoW/mackerel-plugin-prometheus-exporter/blob/7f417f9a8b4644a89c5e6ad92f9c9ea00fc14f85/prome/prometheus.go#L200) is good enough, so I deleted this one(https://github.com/k1LoW/mackerel-plugin-prometheus-exporter/blob/7f417f9a8b4644a89c5e6ad92f9c9ea00fc14f85/prome/prometheus.go#L208).

and added gzip test.