### PR TITLE
Output error information in NewPlugin()

### DIFF
--- a/prome/prometheus.go
+++ b/prome/prometheus.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"regexp"
 	"strings"
@@ -52,7 +53,7 @@ func NewPlugin(ctx context.Context, client *http.Client, targets []string, prefi
 
 	mutex := new(sync.Mutex)
 	wg := &sync.WaitGroup{}
-	errChan := make(chan error, len(targets)) // TODO: output log
+	errChan := make(chan error, len(targets))
 
 	for _, t := range targets {
 		wg.Add(1)
@@ -133,6 +134,10 @@ func NewPlugin(ctx context.Context, client *http.Client, targets []string, prefi
 		}(t)
 	}
 	wg.Wait()
+	close(errChan)
+	for err := range errChan {
+		log.Println("Warn:", err)
+	}
 
 	return p, nil
 }

--- a/prome/prometheus.go
+++ b/prome/prometheus.go
@@ -62,7 +62,7 @@ func NewPlugin(ctx context.Context, client *http.Client, targets []string, prefi
 			var buf = new(bytes.Buffer)
 			_, err := p.scrape(ctx, t, buf)
 			if err != nil {
-				errChan <- err
+				errChan <- fmt.Errorf("scrape failed: %s", err)
 				return
 			}
 
@@ -76,7 +76,7 @@ func NewPlugin(ctx context.Context, client *http.Client, targets []string, prefi
 					if err == io.EOF {
 						break
 					}
-					errChan <- err
+					errChan <- fmt.Errorf("parse failed: %s", err)
 					return
 				}
 				switch et {


### PR DESCRIPTION
Output error information.

I wasn't sure if I should use the `cmd` package to output the logs, but I used the `prome` package to output the logs, referring to the official plugin( https://github.com/mackerelio/mackerel-agent-plugins/blob/master/mackerel-plugin-mysql/lib/mysql.go#L935 ).
I'm not sure how I should do to output log...

With this patch, the following logs are output.
```
$ go run main.go --target hoge --target http://hoge.fuga --target http://localhost:8080/
2022/02/09 18:19:10 Warn: scrape failed: Get "hoge": unsupported protocol scheme ""
2022/02/09 18:19:10 Warn: scrape failed: Get "http://hoge.fuga": dial tcp: lookup hoge.fuga: no such host
2022/02/09 18:19:10 Warn: parse failed: "INVALID" is not a valid start token
```